### PR TITLE
Adjusted displacement_threshold and relative_angle_threshold in PurePursuit

### DIFF
--- a/ros/src/camera_info_publisher/yaml_to_camera_info_publisher.py
+++ b/ros/src/camera_info_publisher/yaml_to_camera_info_publisher.py
@@ -38,7 +38,7 @@ def yaml_to_CameraInfo(calib_yaml):
         data
     """
     # Load data from file
-    calib_data = yaml.load(calib_yaml)
+    calib_data = yaml.safe_load(calib_yaml)
     # Parse
     camera_info_msg = CameraInfo()
     camera_info_msg.width = calib_data["image_width"]

--- a/ros/src/tl_detector/tl_detector.py
+++ b/ros/src/tl_detector/tl_detector.py
@@ -40,7 +40,7 @@ class TLDetector(object):
         rospy.Subscriber('/image_color', Image, self.image_cb)
 
         config_string = rospy.get_param("/traffic_light_config")
-        self.config = yaml.load(config_string)
+        self.config = yaml.safe_load(config_string)
 
         self.upcoming_red_light_pub = rospy.Publisher('/traffic_waypoint', Int32, queue_size=1)
 
@@ -71,7 +71,7 @@ class TLDetector(object):
         :type msg: Lane
         """
         self.waypoints_msg = msg
-        if not self.waypoints_2d:
+        if self.waypoints_2d is None:
             self.waypoints_2d = [(wp.pose.pose.position.x, wp.pose.pose.position.y)
                                  for wp in self.waypoints_msg.waypoints]
             self.waypoint_tree = KDTree(self.waypoints_2d)
@@ -163,7 +163,7 @@ class TLDetector(object):
         # List of positions that correspond to the line to stop in front of for a given intersection.
         stop_line_positions = self.config['stop_line_positions']
 
-        if self.pose_msg is not None:
+        if not (None in (self.pose_msg, self.waypoints_msg, self.waypoint_tree)):
             car_wp_idx = self.get_closest_waypoint(self.pose_msg.pose.position.x,
                                                    self.pose_msg.pose.position.y)
 
@@ -179,7 +179,7 @@ class TLDetector(object):
                     closest_light = light
                     line_wp_idx = temp_wp_idx
 
-        if closest_light:
+        if not (None in (closest_light, line_wp_idx)):
             state = self.get_light_state(closest_light)
             return line_wp_idx, state
 

--- a/ros/src/twist_controller/dbw_node.py
+++ b/ros/src/twist_controller/dbw_node.py
@@ -4,7 +4,6 @@ import rospy
 from std_msgs.msg import Bool
 from dbw_mkz_msgs.msg import ThrottleCmd, SteeringCmd, BrakeCmd, SteeringReport
 from geometry_msgs.msg import TwistStamped
-import math
 
 from twist_controller import Controller
 
@@ -31,7 +30,9 @@ that we have created in the `__init__` function.
 
 '''
 
+
 class DBWNode(object):
+
     def __init__(self):
         rospy.init_node('dbw_node')
 
@@ -79,12 +80,9 @@ class DBWNode(object):
     def loop(self):
         rate = rospy.Rate(50)  # 50Hz
         while not rospy.is_shutdown():
-            if not (None in (self.current_vel, self.linear_vel, self.angular_vel)):
-                self.throttle, self.brake, self.steering = \
-                    self.controller.control(self.current_vel,
-                                            self.dbw_enabled,
-                                            self.linear_vel,
-                                            self.angular_vel)
+            self.throttle, self.brake, self.steering = \
+                self.controller.control(self.current_vel, self.dbw_enabled,
+                                        self.linear_vel, self.angular_vel)
             if self.dbw_enabled:
                 self.publish(self.throttle, self.brake, self.steering)
             rate.sleep()

--- a/ros/src/twist_controller/lowpass.py
+++ b/ros/src/twist_controller/lowpass.py
@@ -2,7 +2,7 @@
 class LowPassFilter(object):
     def __init__(self, tau, ts):
         self.a = 1. / (tau / ts + 1.)
-        self.b = tau / ts / (tau / ts + 1.);
+        self.b = tau / ts / (tau / ts + 1.)
 
         self.last_val = 0.
         self.ready = False

--- a/ros/src/twist_controller/pid.py
+++ b/ros/src/twist_controller/pid.py
@@ -18,10 +18,10 @@ class PID(object):
 
     def step(self, error, sample_time):
 
-        integral = self.int_val + error * sample_time;
-        derivative = (error - self.last_error) / sample_time;
+        integral = self.int_val + error * sample_time
+        derivative = (error - self.last_error) / sample_time
 
-        val = self.kp * error + self.ki * integral + self.kd * derivative;
+        val = self.kp * error + self.ki * integral + self.kd * derivative
 
         if val > self.max:
             val = self.max

--- a/ros/src/twist_controller/yaw_controller.py
+++ b/ros/src/twist_controller/yaw_controller.py
@@ -27,5 +27,4 @@ class YawController(object):
 
         if abs(angular_velocity) > 0.0:
             return self.get_angle(max(current_velocity, self.min_speed) / angular_velocity)
-        else:
-            return 0.0
+        return 0.0

--- a/ros/src/waypoint_follower/include/pure_pursuit_core.h
+++ b/ros/src/waypoint_follower/include/pure_pursuit_core.h
@@ -98,8 +98,8 @@ public:
     , initial_velocity_(5.0)
     , lookahead_distance_calc_ratio_(2.0)
     , minimum_lookahead_distance_(6.0)
-    , displacement_threshold_(0.2)
-    , relative_angle_threshold_(5.)
+    , displacement_threshold_(0.1)   // value in original implementation: 0.2
+    , relative_angle_threshold_(1.0) // value in original implementation: 5.0
     , waypoint_set_(false)
     , pose_set_(false)
     , velocity_set_(false)

--- a/ros/src/waypoint_follower/include/pure_pursuit_core.h
+++ b/ros/src/waypoint_follower/include/pure_pursuit_core.h
@@ -98,8 +98,8 @@ public:
     , initial_velocity_(5.0)
     , lookahead_distance_calc_ratio_(2.0)
     , minimum_lookahead_distance_(6.0)
-    , displacement_threshold_(0.1)   // value in original implementation: 0.2
-    , relative_angle_threshold_(1.0) // value in original implementation: 5.0
+    , displacement_threshold_(0.05)   // value in original implementation: 0.2
+    , relative_angle_threshold_(0.5) // value in original implementation: 5.0
     , waypoint_set_(false)
     , pose_set_(false)
     , velocity_set_(false)

--- a/ros/src/waypoint_follower/src/pure_pursuit_core.cpp
+++ b/ros/src/waypoint_follower/src/pure_pursuit_core.cpp
@@ -250,41 +250,28 @@ bool PurePursuit::verifyFollowing() const
   }
 }
 
-////////////////////////////////////////////////
-// CHANGED THIS TO AVOID WANDERING OF THE CAR //
-////////////////////////////////////////////////
-//geometry_msgs::Twist PurePursuit::calcTwist(double curvature, double cmd_velocity) const
-//{
-//  // verify whether vehicle is following the path
-//  bool following_flag = verifyFollowing();
-//  static double prev_angular_velocity = 0;
-//
-//  geometry_msgs::Twist twist;
-//  twist.linear.x = cmd_velocity;
-//
-//  if (!following_flag)
-//  {
-//    //ROS_ERROR_STREAM("Not following");
-//    twist.angular.z = current_velocity_.twist.linear.x * curvature;
-//  }
-//  else
-//  {
-//    twist.angular.z = prev_angular_velocity;
-//  }
-//
-//  prev_angular_velocity = twist.angular.z;
-//  return twist;
-//}
 geometry_msgs::Twist PurePursuit::calcTwist(double curvature, double cmd_velocity) const
 {
+  // verify whether vehicle is following the path
+  bool following_flag = verifyFollowing();
+  static double prev_angular_velocity = 0;
+
   geometry_msgs::Twist twist;
   twist.linear.x = cmd_velocity;
-  twist.angular.z = current_velocity_.twist.linear.x * curvature;
+
+  if (!following_flag)
+  {
+    //ROS_ERROR_STREAM("Not following");
+    twist.angular.z = current_velocity_.twist.linear.x * curvature;
+  }
+  else
+  {
+    twist.angular.z = prev_angular_velocity;
+  }
+
+  prev_angular_velocity = twist.angular.z;
   return twist;
 }
-////////////////////////////////////////////////
-// CHANGED THIS TO AVOID WANDERING OF THE CAR //
-////////////////////////////////////////////////
 
 void PurePursuit::getNextWaypoint()
 {

--- a/ros/src/waypoint_updater/waypoint_updater.py
+++ b/ros/src/waypoint_updater/waypoint_updater.py
@@ -50,7 +50,7 @@ class WaypointUpdater(object):
     def loop(self):
         rate = rospy.Rate(50)
         while not rospy.is_shutdown():
-            if self.pose_msg and self.base_waypoints_msg:
+            if not (None in (self.pose_msg, self.base_waypoints_msg, self.waypoints_2d, self.waypoint_tree)):
                 self.publish_waypoints()
             rate.sleep()
 
@@ -94,7 +94,7 @@ class WaypointUpdater(object):
         lane = Lane()
 
         closest_idx = self.get_closest_waypoint_index()
-        farthest_idx = closest_idx+ LOOKAHEAD_WPS
+        farthest_idx = closest_idx + LOOKAHEAD_WPS
         base_waypoints = self.base_waypoints_msg.waypoints[closest_idx:farthest_idx]
 
         if self.stopline_wp_idx == -1 or (self.stopline_wp_idx >= farthest_idx):
@@ -139,7 +139,7 @@ class WaypointUpdater(object):
         :type msg: Lane
         """
         self.base_waypoints_msg = msg
-        if not self.waypoints_2d:
+        if self.waypoints_2d is None:
             self.waypoints_2d = [(wp.pose.pose.position.x, wp.pose.pose.position.y)
                                  for wp in self.base_waypoints_msg.waypoints]
             self.waypoint_tree = KDTree(self.waypoints_2d)


### PR DESCRIPTION
As it was pointed by @Elgeweily and later pointed again by @Karthikeya108 in #1, it is better to overcome wabbling of a car by adjusting corresponding parameters, rather than rewriting a function to constantly update angular velocity.

@Elgeweily, sorry, I did not see your comment initially, because it was in a "resolved GitHub conversation," which is hidden by default. 

I chose values to be closer to the initial. Choosing values of 0.01 & 0.01 does not show significantly better results on both Highway and Test Lot tracks. 

*UPDATE:* also added fixes for some "bad" places identified by automatic code review programs tiered to this repo. 