### PR TITLE
upgrade pillow version to fix issues running on docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,4 +33,4 @@ VOLUME ["/capstone"]
 VOLUME ["/root/.ros/log/"]
 WORKDIR /capstone/ros
 
-ENTRYPOINT ["bash", "../entrypoint.sh"]
+CMD ["bash", "../entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,3 +32,5 @@ RUN mkdir /capstone
 VOLUME ["/capstone"]
 VOLUME ["/root/.ros/log/"]
 WORKDIR /capstone/ros
+
+ENTRYPOINT ["bash", "../entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,5 @@
+echo "source /opt/ros/kinetic/setup.bash" >> ~/.bashrc
+source ~/.bashrc
+pip uninstall --yes Pillow
+yes | pip install Pillow==4.3
+bash

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ attrdict==2.0.0
 eventlet==0.19.0
 python-socketio==1.6.1
 numpy==1.13.1
-Pillow==4.3
+Pillow==2.2.1
 scipy==0.19.1
 keras==2.0.8
 tensorflow==1.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ attrdict==2.0.0
 eventlet==0.19.0
 python-socketio==1.6.1
 numpy==1.13.1
-Pillow==2.2.1
+Pillow==4.3
 scipy==0.19.1
 keras==2.0.8
 tensorflow==1.3.0


### PR DESCRIPTION
After running 'roslaunch launch/styx.launch' from the Docker image while the simulator is running and the connection is established, then once I click on the camera check box, I get thse errors in ros (the errors are repetitive as long as there's a connection):

```
message handler error
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/engineio/server.py", line 405, in _trigger_event
    return self.handlers[event](*args)
  File "/usr/local/lib/python2.7/dist-packages/socketio/server.py", line 509, in _handle_eio_message
    self._handle_event(sid, pkt.namespace, pkt.id, pkt.data)
  File "/usr/local/lib/python2.7/dist-packages/socketio/server.py", line 448, in _handle_event
    self._handle_event_internal(self, sid, data, namespace, id)
  File "/usr/local/lib/python2.7/dist-packages/socketio/server.py", line 451, in _handle_event_internal
    r = server._trigger_event(data[0], namespace, sid, *data[1:])
  File "/usr/local/lib/python2.7/dist-packages/socketio/server.py", line 480, in _trigger_event
    return self.handlers[namespace][event](*args)
  File "/capstone/ros/src/styx/server.py", line 60, in image
    bridge.publish_camera(data)
  File "/capstone/ros/src/styx/bridge.py", line 182, in publish_camera
    image_message = self.bridge.cv2_to_imgmsg(image_array, encoding="rgb8")
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/cv_bridge/core.py", line 248, in cv2_to_imgmsg
    img_msg.height = cvim.shape[0]
IndexError: tuple index out of range
```

Fix is to upgrade Pillow version. Mentioned here:
https://github.com/udacity/CarND-Capstone/issues/147

