### PR TITLE
add build script for convenience

### DIFF
--- a/ros/build.sh
+++ b/ros/build.sh
@@ -1,0 +1,4 @@
+cd ~/CarND-CapStone/ros
+catkin_make
+source devel/setup.bash
+roslaunch launch/styx.launch


### PR DESCRIPTION
added a shell script to build, source env and run roslaunch all in one command. To use this, just run

./build.sh


@pkorivi i think you can add command line flags support and pass it to the line where we call roslaunch in order to control env (simulator or carla) and models choice