### PR TITLE
(! URGENT !) Refactoring: Implemented Factory Method for TLClassifier

### DIFF
--- a/ros/src/tl_detector/light_classification/test_tl_classifier.py
+++ b/ros/src/tl_detector/light_classification/test_tl_classifier.py
@@ -17,7 +17,7 @@ class TLClassifierTest(TestCase):
     @classmethod
     def tearDownClass(cls):
         """TODO (Sergey Morozov): remove and use rostest or rosunit"""
-        # stor roscore
+        # stop roscore
         cls.ROS_LAUNCH_PARENT.shutdown()
 
     def setUp(self):

--- a/ros/src/tl_detector/light_classification/test_tl_classifier.py
+++ b/ros/src/tl_detector/light_classification/test_tl_classifier.py
@@ -1,0 +1,52 @@
+import rospy
+from unittest import TestCase
+from light_classification.tl_classifier import TLClassifier, OpenCVTrafficLightsClassifier
+from roslaunch.parent import ROSLaunchParent
+
+
+class TLClassifierTest(TestCase):
+
+    ROS_LAUNCH_PARENT = ROSLaunchParent("TLClassifierTest", [], is_core=True)
+
+    @classmethod
+    def setUpClass(cls):
+        """TODO (Sergey Morozov): remove and use rostest or rosunit"""
+        # start roscore
+        cls.ROS_LAUNCH_PARENT.start()
+
+    @classmethod
+    def tearDownClass(cls):
+        """TODO (Sergey Morozov): remove and use rostest or rosunit"""
+        # stor roscore
+        cls.ROS_LAUNCH_PARENT.shutdown()
+
+    def setUp(self):
+        TLClassifier.INSTANCE = None
+        TLClassifier.KNOWN_TRAFFIC_LIGHT_CLASSIFIERS = {}
+        TLClassifier.register_subclass("opencv")(OpenCVTrafficLightsClassifier)
+
+    def tearDown(self):
+        TLClassifier.INSTANCE = None
+        TLClassifier.KNOWN_TRAFFIC_LIGHT_CLASSIFIERS = {}
+        TLClassifier.register_subclass("opencv")(OpenCVTrafficLightsClassifier)
+
+    def test_get_instance_of(self):
+        instance = TLClassifier.get_instance_of("opencv")
+        self.assertIsInstance(instance, OpenCVTrafficLightsClassifier)
+        self.assertEqual(1, len(TLClassifier.KNOWN_TRAFFIC_LIGHT_CLASSIFIERS))
+
+    def test_classify(self):
+
+        @TLClassifier.register_subclass('mock')
+        class MockTLClassifier(TLClassifier):
+            def __init__(self):
+                super(MockTLClassifier, self).__init__(self.__class__.__name__)
+
+            def _classify(self, image):
+                pass
+
+        rospy.init_node('test_tl_classifier', anonymous=True)
+        mock_instance = TLClassifier.get_instance_of('mock')
+        for i in range(100):
+            mock_instance.classify(None)
+        self.assertEqual(100, mock_instance._counter)

--- a/ros/src/tl_detector/light_classification/tl_classifier.py
+++ b/ros/src/tl_detector/light_classification/tl_classifier.py
@@ -1,78 +1,160 @@
-from styx_msgs.msg import TrafficLight
-import cv2
-import numpy as np
-from time import time
 import rospy
+import cv2
+import sys
+import threading
+import numpy as np
+from styx_msgs.msg import TrafficLight
+from abc import ABCMeta, abstractmethod
+
 
 class TLClassifier(object):
-    def __init__(self, is_site, classifier):
-        self.is_site = is_site
-        self.classifier = classifier
-        rospy.loginfo("Site : %s, classifier : %s",self.is_site,self.classifier)
-        
-        #DO loading of model etc if the classifier is dl based
-        
+    """
+    Base class for traffic light classifiers. The subclasses should provide implementations for the following methods:
+        TLClassifier._classify(self, image)
+        <TLClassifier-Subclass>.__init__(self)
+    Note that <TLClassifier-Subclass>.__init__(self) must invoke its parent constructor
+    and should not have input arguments except self.
+    """
 
-    def simple_opencv_red_color_classifier(self,image):
-        start = time()
+    __metaclass__ = ABCMeta
+
+    INSTANCE = None
+    KNOWN_TRAFFIC_LIGHT_CLASSIFIERS = {}  # it is not empty; it is filled by TLClassifier.register_subclass decorator
+
+    @classmethod
+    def register_subclass(cls, cls_id):
+        """
+        Decorator for TLClassifier subclasses.
+        Adds annotated class to the cls.KNOWN_TRAFFIC_LIGHT_CLASSIFIERS dictionary.
+        :param cls_id: string identifier of the classifier
+        :return: function object
+        """
+        def reg_subclass(cls_type):
+            cls.KNOWN_TRAFFIC_LIGHT_CLASSIFIERS[cls_id] = cls_type
+            return cls_type
+        return reg_subclass
+
+    @classmethod
+    def get_instance_of(cls, classifier_name):
+        """
+        This is a factory method for the `tl_classifier` module. It returns an instance of classifier
+        based on the input argument provided.
+        :param classifier_name: name of the classifier
+        :type classifier_name: str
+        :return: instance of the classifier corresponding to the classifier string identifier
+        :rtype: TLClassifier
+        """
+        if cls.INSTANCE is not None \
+                and type(cls.INSTANCE) != cls.KNOWN_TRAFFIC_LIGHT_CLASSIFIERS[classifier_name]:
+            raise ValueError("cannot instantiate an instance of " + classifier_name
+                             + " classifier since an instance of another type (" + type(cls.INSTANCE).__name__ +
+                             ") has already been instantiated")
+
+        if cls.INSTANCE is not None:
+            return cls.INSTANCE
+
+        classifier_type = cls.KNOWN_TRAFFIC_LIGHT_CLASSIFIERS.get(classifier_name, None)
+        if classifier_type is None:
+            raise ValueError("classifier_name parameter has unknown value: " + classifier_name
+                             + "; the value should be in " + str(cls.KNOWN_TRAFFIC_LIGHT_CLASSIFIERS.keys()))
+        cls.INSTANCE = classifier_type()
+
+        return cls.INSTANCE
+
+    @abstractmethod
+    def _classify(self, image):
+        """
+        Determines the color of the traffic light in the image.
+        This method should be implemented by a particular type of the traffic light classifier.
+
+        :param image: image containing the traffic light
+        :type image: np.ndarray
+        :returns: ID of traffic light color (specified in styx_msgs/TrafficLight)
+        :rtype: int
+        """
+        raise NotImplementedError()
+
+    def classify(self, image):
+        """
+        Determines the color of the traffic light in the image.
+        Prints FPS statistics approximately each second.
+
+        :param image: image containing the traffic light
+        :type image: np.ndarray
+        :returns: ID of traffic light color (specified in styx_msgs/TrafficLight)
+        :rtype: int
+        """
+        # calculate FPS based on the number of images processed per second;
+        # ensure that self._counter value does not go over integer limits
+        with self._lock:
+            if self._start_time is None or self._counter > (sys.maxint - 100):
+                self._start_time = rospy.get_time()
+                self._counter = 0
+            self._counter += 1
+            # save start time and counter values for processing outside of the syncronized block
+            start_t = self._start_time
+            counter = self._counter
+
+        tl_state = self._classify(image)
+
+        # log the FPS no faster than once per second
+        diff_t =  rospy.get_time() - start_t
+        fps = None
+        if diff_t >= 1.0:
+            fps = int(counter / diff_t)
+        if fps is not None:  # do not log while there are only a few images processed
+            rospy.logdebug_throttle(1.0, "FPS: %d" % fps)
+
+        return tl_state
+
+    @abstractmethod
+    def __init__(self, cls_name):
+        """
+        Constructor is marked as @abstractmethod to force implemnting __init__ method in subclasses.
+        Subclasses must invoke their parent constructors.
+        :param cls_name: string identifier of the sub-class.
+        """
+        rospy.loginfo("instantiating %s (available classifiers: %s)",
+                      cls_name, str(self.KNOWN_TRAFFIC_LIGHT_CLASSIFIERS.keys()))
+
+        self._lock = threading.Lock()  # lock to be used in TLClassifier.classify to increment invocation counter
+        self._counter = 0
+        self._start_time = None
+
+
+@TLClassifier.register_subclass('opencv')
+class OpenCVTrafficLightsClassifier(TLClassifier):
+    """
+    Detects and classifies traffic lights on images with Compute Vision methods.
+    """
+
+    def _classify(self, image):
         hsv = cv2.cvtColor(image, cv2.COLOR_BGR2HSV)
 
         lower_red1 = np.array([0, 100, 100])
-        upper_red1 = np.array([10, 255,255])
-        lower_red2 = np.array([160,100,100])
-        upper_red2 = np.array([179,255,255])
+        upper_red1 = np.array([10, 255, 255])
+        lower_red2 = np.array([160, 100, 100])
+        upper_red2 = np.array([179, 255, 255])
 
         mask1 = cv2.inRange(hsv, lower_red1, upper_red1)
         mask2 = cv2.inRange(hsv, lower_red2, upper_red2)
-        red_img = cv2.addWeighted(mask1,1.0,mask2,1.0,0)
+        red_img = cv2.addWeighted(mask1, 1.0, mask2, 1.0, 0)
 
-        im, contours, hierarchy = cv2.findContours(red_img,cv2.RETR_TREE,cv2.CHAIN_APPROX_SIMPLE)
+        im, contours, hierarchy = cv2.findContours(red_img, cv2.RETR_TREE, cv2.CHAIN_APPROX_SIMPLE)
         red_count = 0
-        for x,contour in enumerate(contours):
-            contourarea = cv2.contourArea(contour) #get area of contour
-            if 18 < contourarea < 900: #Discard contours with a too large area as this may just be noise
+        for x, contour in enumerate(contours):
+            contourarea = cv2.contourArea(contour)  # get area of contour
+            if 18 < contourarea < 900:  # Discard contours with a too large area as this may just be noise
                 arclength = cv2.arcLength(contour, True)
                 approxcontour = cv2.approxPolyDP(contour, 0.01 * arclength, True)
-                #Check for Square
-                if len(approxcontour)>5:
+                # Check for Square
+                if len(approxcontour) > 5:
                     red_count += 1
-        end = time()
-        fps = 1.0 / (end - start)
-        rospy.loginfo("Red count: %d , FPS: %.2f" % (red_count, fps))
+        rospy.logdebug("Red count: %d", red_count)
         if red_count > 0:
             return TrafficLight.RED
 
         return TrafficLight.UNKNOWN
 
-    def dl_ssd_classifier_carla(self,image):
-        return TrafficLight.UNKNOWN
-    
-    def dl_ssd_classifier_sim(self,image):
-        return TrafficLight.UNKNOWN
-
-    def get_classification(self, image):
-        """Determines the color of the traffic light in the image
-
-        Args:
-            image (cv::Mat): image containing the traffic light
-
-        Returns:
-            int: ID of traffic light color (specified in styx_msgs/TrafficLight)
-
-        """
-        #call classifier for the site - real data
-        if(self.is_site):
-            if(self.classifier == "opencv"):
-                return self.simple_opencv_red_color_classifier(image)
-            elif(self.classifier == "dl_ssd"):
-                self.dl_ssd_classifier_carla(image)
-
-        #is_site is flase - call simulation classiier
-        if(self.classifier == "opencv"):
-            return self.simple_opencv_red_color_classifier(image)
-        elif(self.classifier == "dl_ssd"):
-            return self.dl_ssd_classifier_sim(image)
-
-        #Default - use the simple opencv version if nothing is specified
-        return self.simple_opencv_red_color_classifier(image)
-        
+    def __init__(self):
+        super(OpenCVTrafficLightsClassifier, self).__init__(self.__class__.__name__)

--- a/ros/src/tl_detector/light_classification/tl_classifier.py
+++ b/ros/src/tl_detector/light_classification/tl_classifier.py
@@ -25,7 +25,7 @@ class TLClassifier(object):
     def register_subclass(cls, cls_id):
         """
         Decorator for TLClassifier subclasses.
-        Adds annotated class to the cls.KNOWN_TRAFFIC_LIGHT_CLASSIFIERS dictionary.
+        Adds decorated class to the cls.KNOWN_TRAFFIC_LIGHT_CLASSIFIERS dictionary.
         :param cls_id: string identifier of the classifier
         :return: function object
         """
@@ -37,7 +37,7 @@ class TLClassifier(object):
     @classmethod
     def get_instance_of(cls, classifier_name):
         """
-        This is a factory method for the `tl_classifier` module. It returns an instance of classifier
+        It is a factory method for the `tl_classifier` module. It returns an instance of the classifier
         based on the input argument provided.
         :param classifier_name: name of the classifier
         :type classifier_name: str
@@ -77,7 +77,7 @@ class TLClassifier(object):
     def classify(self, image):
         """
         Determines the color of the traffic light in the image.
-        Prints FPS statistics approximately each second.
+        Prints FPS statistic approximately each second.
 
         :param image: image containing the traffic light
         :type image: np.ndarray
@@ -91,7 +91,7 @@ class TLClassifier(object):
                 self._start_time = rospy.get_time()
                 self._counter = 0
             self._counter += 1
-            # save start time and counter values for processing outside of the syncronized block
+            # save start time and counter values for processing outside of the critical section
             start_t = self._start_time
             counter = self._counter
 
@@ -110,9 +110,9 @@ class TLClassifier(object):
     @abstractmethod
     def __init__(self, cls_name):
         """
-        Constructor is marked as @abstractmethod to force implemnting __init__ method in subclasses.
+        Constructor is marked as @abstractmethod to force implemnting the __init__ method in subclasses.
         Subclasses must invoke their parent constructors.
-        :param cls_name: string identifier of the sub-class.
+        :param cls_name: string identifier of the subclass.
         """
         rospy.loginfo("instantiating %s (available classifiers: %s)",
                       cls_name, str(self.KNOWN_TRAFFIC_LIGHT_CLASSIFIERS.keys()))
@@ -125,7 +125,7 @@ class TLClassifier(object):
 @TLClassifier.register_subclass('opencv')
 class OpenCVTrafficLightsClassifier(TLClassifier):
     """
-    Detects and classifies traffic lights on images with Compute Vision methods.
+    Detects and classifies traffic lights on images with Computer Vision techniques.
     """
 
     def _classify(self, image):

--- a/ros/src/tl_detector/tl_detector.py
+++ b/ros/src/tl_detector/tl_detector.py
@@ -17,6 +17,11 @@ STATE_COUNT_THRESHOLD = 3
 
 class TLDetector(object):
     def __init__(self):
+
+        # set log_level=rospy.DEBUG to print useful debug information, such as TLClassifier FPS, to /rosout;
+        # keep this line on top of this method to avoid problems
+        rospy.init_node('tl_detector', log_level=rospy.INFO)
+
         self.pose_msg = None
         self.waypoints_msg = None
         self.waypoints_2d = None
@@ -36,9 +41,6 @@ class TLDetector(object):
         self.last_wp = -1
         self.state_count = 0
         self.has_image = False
-
-        # set log_level=rospy.DEBUG to print useful debug information, such as TLClassifier FPS, to /rosout
-        rospy.init_node('tl_detector', log_level=rospy.INFO)
 
         rospy.Subscriber('/current_pose', PoseStamped, self.pose_cb)
         rospy.Subscriber('/base_waypoints', Lane, self.waypoints_cb)

--- a/ros/src/tl_detector/tl_detector.py
+++ b/ros/src/tl_detector/tl_detector.py
@@ -17,8 +17,6 @@ STATE_COUNT_THRESHOLD = 3
 
 class TLDetector(object):
     def __init__(self):
-        rospy.init_node('tl_detector')
-
         self.pose_msg = None
         self.waypoints_msg = None
         self.waypoints_2d = None
@@ -26,29 +24,11 @@ class TLDetector(object):
         self.camera_image_msg = None
         self.lights = []
 
-        rospy.Subscriber('/current_pose', PoseStamped, self.pose_cb)
-        rospy.Subscriber('/base_waypoints', Lane, self.waypoints_cb)
-
-        '''
-        /vehicle/traffic_lights provides you with the location of the traffic light in 3D map space and
-        helps you acquire an accurate ground truth data source for the traffic light
-        classifier by sending the current color state of all traffic lights in the
-        simulator. When testing on the vehicle, the color state will not be available. You'll need to
-        rely on the position of the light and the camera image to predict it.
-        '''
-        rospy.Subscriber('/vehicle/traffic_lights', TrafficLightArray, self.traffic_cb)
-        rospy.Subscriber('/image_color', Image, self.image_cb)
-
         config_string = rospy.get_param("/traffic_light_config")
         self.config = yaml.safe_load(config_string)
 
-        self.is_site = self.config['is_site']
-        self.classifier = self.config['classifier']
-
-        self.upcoming_red_light_pub = rospy.Publisher('/traffic_waypoint', Int32, queue_size=1)
-
         self.bridge = CvBridge()
-        self.light_classifier = TLClassifier(self.is_site,self.classifier)
+        self.light_classifier = TLClassifier.get_instance_of(self.config['classifier'])
         self.listener = tf.TransformListener()
 
         self.state = TrafficLight.UNKNOWN
@@ -56,6 +36,24 @@ class TLDetector(object):
         self.last_wp = -1
         self.state_count = 0
         self.has_image = False
+
+        # set log_level=rospy.DEBUG to print useful debug information, such as TLClassifier FPS, to /rosout
+        rospy.init_node('tl_detector', log_level=rospy.INFO)
+
+        rospy.Subscriber('/current_pose', PoseStamped, self.pose_cb)
+        rospy.Subscriber('/base_waypoints', Lane, self.waypoints_cb)
+
+
+        # /vehicle/traffic_lights provides you with the location of the traffic light in 3D map space and
+        # helps you acquire an accurate ground truth data source for the traffic light
+        # classifier by sending the current color state of all traffic lights in the
+        # simulator. When testing on the vehicle, the color state will not be available. You'll need to
+        # rely on the position of the light and the camera image to predict it.
+
+        rospy.Subscriber('/vehicle/traffic_lights', TrafficLightArray, self.traffic_cb)
+        rospy.Subscriber('/image_color', Image, self.image_cb)
+
+        self.upcoming_red_light_pub = rospy.Publisher('/traffic_waypoint', Int32, queue_size=1)
 
         rospy.spin()
 
@@ -121,13 +119,11 @@ class TLDetector(object):
     def get_closest_waypoint(self, x, y):
         """
         Identifies the closest path waypoint to the given position
-            https://en.wikipedia.org/wiki/Closest_pair_of_points_problem
-        Args:
-            pose (Pose): position to match a waypoint to
-
-        Returns:
-            int: index of the closest waypoint in self.waypoints
-
+        https://en.wikipedia.org/wiki/Closest_pair_of_points_problem.
+        :param pose: position to match a waypoint to
+        :type pose: Pose
+        :return: index of the closest waypoint
+        :rtype: int
         """
         return self.waypoint_tree.query((x, y), 1)[1]
 
@@ -141,17 +137,13 @@ class TLDetector(object):
             int: ID of traffic light color (specified in styx_msgs/TrafficLight)
 
         """
-        if(not self.has_image):
+        if not self.has_image:
             self.prev_light_loc = None
             return False
 
         cv_image = self.bridge.imgmsg_to_cv2(self.camera_image_msg, "bgr8")
 
-        #Get classification -  classification method is set in the startup
-        return self.light_classifier.get_classification(cv_image)
-
-        # TODO Remove this once classification is available
-        #return light.state
+        return self.light_classifier.classify(cv_image)
 
     def process_traffic_lights(self):
         """

--- a/ros/src/waypoint_updater/waypoint_updater.py
+++ b/ros/src/waypoint_updater/waypoint_updater.py
@@ -22,7 +22,7 @@ current status in `/vehicle/traffic_lights` message. You can use this message to
 as well as to verify your TL classifier.
 """
 
-LOOKAHEAD_WPS = 100  # Number of waypoints to publish into /final_waypoints topic.
+LOOKAHEAD_WPS = 200  # Number of waypoints to publish into /final_waypoints topic.
 
 MAX_DECEL = 1.0
 


### PR DESCRIPTION
Please, follow the provided structure when creating your classifiers. 
@Elgeweily, please, adopt your PR #8 for this structure (once this PR is merged to _master_)

I have spent a tremendous amount of time trying to adopt the unit test for the _rostest_ or _rosunit_ to be able to execute unit tests with `catkin_make run_tests` but failed to do this. You can run the provided test with `pytest`. It will work, but it does not comply with ROS standards. I would be glad if you suggest me how to integrate this unit test into _catkin_.